### PR TITLE
default localization changed to traditional chinese

### DIFF
--- a/res/values/appupdate_strings.xml
+++ b/res/values/appupdate_strings.xml
@@ -1,18 +1,17 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources>
-    <string name="update_latest">Now you have the latest update</string>
-    <string name="update_title">New update</string>
-    <string name="update_message">The software need to be updated！</string>
-    <string name="update_update_btn">Update</string>
-    <string name="updating">Updating</string>
-    <string name="update_cancel">Cancel</string>
-    <string name="update_bg">Update in background</string>
-    <string name="download_complete">Download complete</string>
-    <string name="download_complete_title">Download complete</string>
-    <string name="download_complete_pos_btn">Download again</string>
-    <string name="download_complete_neu_btn">Install manually</string>
+    <string name="update_latest">已经是最新版本</string>
+    <string name="update_title">软件更新</string>
+    <string name="update_message">软件框架有更新啦！</string>
+    <string name="update_update_btn">更新</string>
+    <string name="updating">正在更新</string>
+    <string name="update_cancel">取消</string>
+    <string name="update_bg">转到后台更新</string>
+    <string name="download_complete_title">下载完毕</string>
+    <string name="download_complete_pos_btn">重新下载</string>
+    <string name="download_complete_neu_btn">手动安装</string>
 
-    <string name="update_error_title">Error</string>
-    <string name="update_error_message">The current network is unavailable , please check your network settings.</string>
-    <string name="update_error_yes_btn">OK</string>
+    <string name="update_error_title">错误</string>
+    <string name="update_error_message">当前网络不可用，请检查你的网络设置。</string>
+    <string name="update_error_yes_btn">知道了</string>
 </resources>


### PR DESCRIPTION
Users  with zh language devices saw simplified chinese, while all the rest chinese locales saw default english, so I changed default values to traditional chinese.
I can't figure out why zh_tw don't use localization from values_zh folder, and I decided it's better for chinese users to see traditional chinese instead of english.